### PR TITLE
Improve get and create order performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov
 .DS_Store
 **/*.log
 stats.xml
+orders/alembic/versions/*_init.py

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -48,6 +48,14 @@ class StorageWrapper:
         for key in keys:
             yield self._from_hash(self.client.hgetall(key))
 
+    def list_by_ids(self, product_ids):
+        for product_id in product_ids:
+            try:
+                product = self.get(product_id)
+                yield product
+            except NotFound:
+                continue
+
     def create(self, product):
         self.client.hmset(
             self._format_key(product['id']),

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -26,6 +26,11 @@ class ProductsService:
         return schemas.Product(many=True).dump(products).data
 
     @rpc
+    def products_by_ids(self, product_ids):
+        products = self.storage.list_by_ids(product_ids)
+        return schemas.Product(many=True).dump(products).data
+
+    @rpc
     def create(self, product):
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)


### PR DESCRIPTION
# Performance is degrading when users are added

In every GET ORDER or CREATE ORDER request, the gateway service makes a RPC call to the Products service to get a full list of all products in the database. This is done to validate if the products in the order actually exist in the database. But a list call is unnecessarily expansive in resources for this purpose. As the requests and database grow, the list request ends up taking too long, creating a bottleneck, thus causing performance degradation.


# How does this Pull Request fix it?

Implementing a new function `products_by_ids` in the product service that gets all requested products and returns them in a list, working as a filtered list function. Under the hood, in the `list_by_ids` function, the service makes one request per product in the order, dealing with less data than the list function that was being used.


### Problematic behavior on 3-minute performance test result

1. Constant 1 user
<img width="1033" alt="request_stat_1_user" src="https://github.com/gitricko/nameko-devex/assets/13365919/5745286b-3e7b-496c-a53f-de48dc2f91d5">

2. From 1 user to 3 user, ramp on minute 1
2.a. Statistics
<img width="1026" alt="request_stat_3_users" src="https://github.com/gitricko/nameko-devex/assets/13365919/645c44de-6822-42e8-8bbb-75e132751823">

2. b. Timeline with exponential time response at user ramp on minute 1
<img width="990" alt="timeline_concurrency_1" src="https://github.com/gitricko/nameko-devex/assets/13365919/f9d51897-4fce-4b7b-ae8a-109c3ae6d17c">

### Fixed behavior on 3-minute performance test result

1. Constant 1 user
<img width="1019" alt="fixed_request_stat_1_user" src="https://github.com/gitricko/nameko-devex/assets/13365919/e5ddca48-6c6f-40d4-8b64-f39f1b39e6b9">

2. From 1 user to 3 user, ramp on minute 1
2.a. Statistics
<img width="1025" alt="fixed_request_stat_3_users" src="https://github.com/gitricko/nameko-devex/assets/13365919/dd7f751a-af65-46b7-a3fe-f416369206ef">


2. b. Timeline time with better response, a small peak, at user ramp on minute 1
<img width="1027" alt="timeline_fixed_concurrency_1" src="https://github.com/gitricko/nameko-devex/assets/13365919/369553d4-dec9-40e6-b0f9-b38f96d4656a">
